### PR TITLE
chore: add github package publish flow

### DIFF
--- a/.github/workflows/npm-publish-github.yml
+++ b/.github/workflows/npm-publish-github.yml
@@ -1,0 +1,38 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      # TODO execute tests in headless browser
+      #- run: npm test
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to GitHub Packages
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "svg-credit-card-payment-icons",
+  "name": "@aaronfagan/ccicons",
   "version": "0.1.0",
   "description": "SVG Credit Card & Payment Icons",
   "main": "src/index.js",


### PR DESCRIPTION
Set up a GitHub workflow that publishes an npm package to GitHub Package Repository.

Remaining work:
- tests need to be executed in a headless browser